### PR TITLE
add support for syncing binary files stored in automerge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ it's currently hardwired to talk to `wss://sync.automerge.org`, tho you can over
 ## examples of things you can do with it
 
 ```sh
-# mirror a string at a path in an Automerge document to raw file contents
+# mirror a string at a path in an Automerge document to n file contents
 amtool cp -wr automerge:2Nn5c23EuinsRJ7duZ9ATb1rZTQJ/content doc.md
 
 # mirror the other way around
@@ -15,6 +15,9 @@ amtool cp -wr doc.md automerge:2Nn5c23EuinsRJ7duZ9ATb1rZTQJ/content
 
 # mirror a value in Automerge to JSON in a file
 amtool cp -w automerge:2Nn5c23EuinsRJ7duZ9ATb1rZTQJ doc.json
+
+# mirror an Automerge file system to disk
+amtool cp -wf automerge:WL55H9f3cw91kvAoSNXMCL7ip6i/files ./assets
 
 # stream some values into Automerge
 while true; do

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,24 +1,26 @@
 {
   "name": "amtool",
-  "version": "0.0.8",
+  "version": "0.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "amtool",
-      "version": "0.0.8",
+      "version": "0.0.10",
       "license": "MIT",
       "dependencies": {
         "@automerge/automerge-repo": "^1.1.1",
         "@automerge/automerge-repo-network-websocket": "^1.1.1",
         "chokidar": "^3.6.0",
-        "cmd-ts": "^0.13.0"
+        "cmd-ts": "^0.13.0",
+        "fs-extra": "^11.2.0"
       },
       "bin": {
         "amtool": "bin/amtool.js"
       },
       "devDependencies": {
         "@types/chokidar": "^2.1.3",
+        "@types/fs-extra": "^11.0.4",
         "@types/node": "^20.11.19",
         "typescript": "^5.3.3"
       }
@@ -211,6 +213,25 @@
       "dev": true,
       "dependencies": {
         "chokidar": "*"
+      }
+    },
+    "node_modules/@types/fs-extra": {
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-11.0.4.tgz",
+      "integrity": "sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/jsonfile": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/jsonfile": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/@types/jsonfile/-/jsonfile-6.1.4.tgz",
+      "integrity": "sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/node": {
@@ -478,6 +499,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/fs-extra": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -501,6 +535,11 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -554,6 +593,17 @@
       "integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
       "peerDependencies": {
         "ws": "*"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
       }
     },
     "node_modules/make-error": {
@@ -706,6 +756,14 @@
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
     },
     "node_modules/uuid": {
       "version": "9.0.1",

--- a/package.json
+++ b/package.json
@@ -20,10 +20,12 @@
     "@automerge/automerge-repo": "^1.1.1",
     "@automerge/automerge-repo-network-websocket": "^1.1.1",
     "chokidar": "^3.6.0",
-    "cmd-ts": "^0.13.0"
+    "cmd-ts": "^0.13.0",
+    "fs-extra": "^11.2.0"
   },
   "devDependencies": {
     "@types/chokidar": "^2.1.3",
+    "@types/fs-extra": "^11.0.4",
     "@types/node": "^20.11.19",
     "typescript": "^5.3.3"
   }


### PR DESCRIPTION
This pull request adds support for syncing files stored in Automerge to disk.

In tee / trail-runner we use the convention that a file system can be expressed in Automerge as nested maps. Files are objects that have a `contentType` property and a `contents` property like this:
```
{
  foo: {
    bar: {
      baz.txt: {
        contentType: "text/plain",
        contents: RawString<contents of file>
      }
    },
    qux.png: {
      contentType: "image/png",
      contents: <binary>
    }
  }
}
```

To sync a file system like this to disk you can use the following command (the f flag indicates that we want to read the path as a file system)

```
amtool cp -wf automerge:WL55H9f3cw91kvAoSNXMCL7ip6i/files
```

It's also possible to copy individual files

```
amtool cp -f automerge:WL55H9f3cw91kvAoSNXMCL7ip6i/files/rose.png
```